### PR TITLE
Add fix for bad commands preventing other commands from being imported in addMultipleIn

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -33,3 +33,12 @@ export class ClusterIPCError extends BaseError {
     this.stack = error.stack;
   }
 }
+
+export class ImportedCommandsError extends BaseError {
+  errors: {[key: string]: Error};
+
+  constructor(errors: {[key: string]: Error}) {
+    super('Error while importing multiple commands');
+    this.errors = errors;
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,15 +8,6 @@ class BaseError extends Error {
   }
 }
 
-export class GatewayHTTPError extends BaseError {
-  httpError: any;
-
-  constructor(message: string, httpError: any) {
-    super(message);
-    this.httpError = httpError;
-  }
-}
-
 export class ClusterIPCError extends BaseError {
   name: string;
   stack: string;
@@ -31,6 +22,15 @@ export class ClusterIPCError extends BaseError {
     super(error.message);
     this.name = error.name;
     this.stack = error.stack;
+  }
+}
+
+export class GatewayHTTPError extends BaseError {
+  httpError: any;
+
+  constructor(message: string, httpError: any) {
+    super(message);
+    this.httpError = httpError;
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where you import a folder with `addMultipleIn` and one of the files somehow fails when being imported, which leads to the next commands not being imported as well, leading to a scenario where you have no commands running. 

With these changes, only the invalid files will be skipped rather than all of them, and the errors caused by the invalid files will be printed after all files have been checked/imported.