### PR TITLE
typings(client): add CacheOptions interface

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -69,8 +69,7 @@ interface GatewayOptions extends Gateway.SocketOptions, GatewayHandlerOptions {
 
 }
 
-export interface ShardClientOptions {
-  cache?: {
+export interface CacheOptions {
     applications?: ApplicationsOptions,
     channels?: ChannelsOptions,
     connectedAccounts?: ConnectedAccountsOptions,
@@ -88,7 +87,10 @@ export interface ShardClientOptions {
     voiceCalls?: VoiceCallsOptions,
     voiceConnections?: VoiceConnectionsOptions,
     voiceStates?: VoiceStatesOptions,
-  } | boolean,
+}
+
+export interface ShardClientOptions {
+  cache?: CacheOptions | boolean,
   gateway?: GatewayOptions,
   imageFormat?: ImageFormats | string,
   isBot?: boolean,


### PR DESCRIPTION
Due to `ShardClientOptions#cache` being defined inline, the documentation makes it unclear what properties it takes.

![chrome_UhaCd7ZovV](https://user-images.githubusercontent.com/30553356/71987364-59851600-322e-11ea-8a04-6053cbd1a2bb.png)

This Pull Request adds a `CacheOptions` interface, so it is clear what the cache actually is and takes instead of being defined as `object`.