### PR TITLE
Remove UNDERAGE_DELETED user flag

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1011,7 +1011,6 @@ export enum UserFlags {
   SYSTEM = 1 << 12,
   HAS_UNREAD_URGENT_MESSAGES = 1 << 13,
   BUG_HUNTER_LEVEL_2 = 1 << 14,
-  UNDERAGE_DELETED = 1 << 15,
   VERIFIED_BOT = 1 << 16,
   VERIFIED_DEVELOPER = 1 << 17,
 };

--- a/src/structures/user.ts
+++ b/src/structures/user.ts
@@ -138,10 +138,6 @@ export class User extends BaseStructure {
     return this.hasFlag(UserFlags.TEAM_USER);
   }
 
-  get hasUnderageDeleted(): boolean {
-    return this.hasFlag(UserFlags.UNDERAGE_DELETED);
-  }
-
   get hasVerifiedBot(): boolean {
     return this.hasFlag(UserFlags.VERIFIED_BOT);
   }


### PR DESCRIPTION
This user flag has been removed as per https://github.com/DJScias/Discord-Datamining/commit/ae6ecdcba9a2cc6c09ab9c7a494c063ec880fe1b#commitcomment-38807673
As such, it will be false for all users and should safely be able to be removed