### PR TITLE
Make VoiceConnectOptions optional

### DIFF
--- a/src/structures/voicestate.ts
+++ b/src/structures/voicestate.ts
@@ -107,7 +107,7 @@ export class VoiceState extends BaseStructure {
     return this.client.rest.editGuildMember(this.guildId, this.userId, options);
   }
 
-  joinVoice(options: VoiceConnectOptions) {
+  joinVoice(options?: VoiceConnectOptions) {
     return this.client.voiceConnect(this.guildId, this.channelId, options);
   }
 


### PR DESCRIPTION
This makes it so that the options for <VoiceState>.joinVoice() are optional as all properties in VoiceConnectOptions are optional