### PR TITLE
Add RestClient.post

### DIFF
--- a/src/rest/client.ts
+++ b/src/rest/client.ts
@@ -117,6 +117,13 @@ export class RestClient {
     return this.raw.patch(info, init);
   }
 
+  async post(
+    info: RequestTypes.Options | string | URL,
+    init?: RequestTypes.Options,
+  ) {
+    return this.raw.post(info, init);
+  }
+
   async put(
     info: RequestTypes.Options | string | URL,
     init?: RequestTypes.Options,


### PR DESCRIPTION
This adds a shorthand method for POST to RestClient similar to already existing methods for GET, PATCH, etc.

Closes #16 