### PR TITLE
feature: autodeploy docs to github pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,18 @@
+name: Deploy docs to Github Pages
+on:
+  push:
+    branches:
+      - master
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: npm install
+      - run: npm run typedoc
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: gh-pages
+          folder: docs


### PR DESCRIPTION
This sets up a Github Action to automatically build and deploy typedoc
pages to Github Pages of this repo when new code is pushed to `master`.

For reference, my fork (https://github.com/SEAPUNK/detritus-client) is set up with this, where you can see that pushes to `master` triggers pushes to the `gh-pages` branch, which in turn publishes to https://seapunk.github.io/detritus-client
