### PR TITLE
feat(Stickers): small refractor to be even with the discord-api docs

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1481,7 +1481,7 @@ export const DiscordKeys = Object.freeze({
   STARTED: 'started',
   STATE: 'state',
   STATUS: 'status',
-  STICKERS: 'stickers',
+  STICKERS: 'sticker_items',
   STOPPED: 'stopped',
   STORE_APPLICATION_STATE: 'store_application_state',
   STORE_LISTING: 'store_listing',

--- a/src/structures/sticker.ts
+++ b/src/structures/sticker.ts
@@ -12,7 +12,11 @@ import {
 
 
 const keysSticker = new BaseSet<string>([
+  /**
+   * @deprecated empty string for now
+   */
   DiscordKeys.ASSET,
+  DiscordKeys.AVAILABLE,
   DiscordKeys.DESCRIPTION,
   DiscordKeys.FORMAT_TYPE,
   DiscordKeys.ID,
@@ -28,15 +32,24 @@ const keysSticker = new BaseSet<string>([
  */
 export class Sticker extends BaseStructure {
   readonly _keys = keysSticker;
-
+  /**
+   * @deprecated previously the sticker asset hash, now an empty string*
+   * 
+   * * The URL for fetching sticker assets is currently private.
+   */
   asset: string = '';
   description: string = '';
   formatType: StickerFormats = StickerFormats.UNKNOWN;
   id: string = '';
+  available: boolean = false;
   name: string = '';
   packId: string = '';
+  /**
+   * @deprecated as the Sticker#asset is currently a private method
+   */
   previewAsset: null | string = null;
   tags: null | string = '';
+  sortValue: number = 0;
 
   constructor(
     client: ShardClient,
@@ -44,7 +57,16 @@ export class Sticker extends BaseStructure {
     isClone?: boolean,
   ) {
     super(client, undefined, isClone);
-    this.merge(data);
+    if (data?.available) {
+      this.available = true;
+      this.merge(data);
+    } else {
+      this.available = false;
+      this.id = data?.id;
+      this.name = data?.name;
+      this.formatType = data?.formatType;
+
+    }
   }
 
   get assetUrl(): string {

--- a/src/structures/sticker.ts
+++ b/src/structures/sticker.ts
@@ -45,7 +45,7 @@ export class Sticker extends BaseStructure {
   name: string = '';
   packId: string = '';
   /**
-   * @deprecated as the Sticker#asset is currently a private method
+   * @deprecated as the Sticker#asset currently unfetchable
    */
   previewAsset: null | string = null;
   tags: null | string = '';
@@ -61,6 +61,8 @@ export class Sticker extends BaseStructure {
       this.available = true;
       this.merge(data);
     } else {
+      //TODO: check if this is always the case that Discord
+      // will send this data if the sticker is not available
       this.available = false;
       this.id = data?.id;
       this.name = data?.name;
@@ -68,7 +70,9 @@ export class Sticker extends BaseStructure {
 
     }
   }
-
+  /**
+   * @deprecated
+   */
   get assetUrl(): string {
     return this.assetUrlFormat();
   }
@@ -91,7 +95,9 @@ export class Sticker extends BaseStructure {
       };
     }
   }
-
+  /**
+   * @deprecated
+   */
   assetUrlFormat(format?: null | string, query?: UrlQuery): string {
     const hash = this.asset;
     if (!format) {


### PR DESCRIPTION
## changes
* as per https://github.com/discord/discord-api-docs/pull/3171 the `stickers` property on the `Message` object has been deprecated and replaced with `sticker_items`.
* deprecated `Sticker.*asset` properties as currently the asset url fetching is private. 
* added check if the sticker is "available" (it's on the discord docs and am curently not aware when this might be the case).

if https://github.com/discord/discord-api-docs/pull/3128 Pull request  gets merged in the next days i will update this pull request to support the new sticker packs/zodates. 