### PR TITLE
Add github link and pnpm install command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ are provided through [`detritus-client-rest`](https://github.com/detritusjs/clie
 
 - `$ npm i detritus-client`
 - `$ yarn add detritus-client`
+- `$ pnpm add detritus-client`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A wheels-attached, pure-TypeScript library for the Discord API.
 
 - [API Documentation](https://detritusjs.com)
 - [Discord Help Server](https://discord.gg/NEq6wws)
+- [Github](https://github.com/detritusjs/client)
 - [npm](https://www.npmjs.com/package/detritus-client)
 
 ## Installation


### PR DESCRIPTION
The GitHub link in the readme is to give people on the autogenerated API docs site an easy way to get back to the Github repo.

The addition of the `pnpm add` command is because [pnpm](https://pnpm.io/) is a competing CLI for the npm registry that is relatively popular. Discord.JS [recently added](https://github.com/discordjs/discord.js/pull/6354/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48) a `pnpm add` command to the installation section of their readme file, which is a good indication that lots of people use it. Lastly, if you are going to list two of the most popular CLIs for npm, what harm is there in adding another?  